### PR TITLE
Not to update apt packages at cloud-init

### DIFF
--- a/cloud-init.yaml
+++ b/cloud-init.yaml
@@ -1,5 +1,5 @@
 #cloud-config
-package_upgrade: true
+package_upgrade: false
 locale: en_US.UTF-8
 apt:
   sources:


### PR DESCRIPTION
This is a workaround for 'timed out waiting for initialization to complete'.

Here are backgrounds:
- multipass timeouts cloud-init in 5 minutes
https://github.com/canonical/multipass/issues/1488#issuecomment-614038829
> We have a hard timeout of 5 minutes waiting for cloud-init to finish.

- cloud-init tooks 338 seconds At rails-dev-box

```
ubuntu@rails-dev-box:/var/log$ cloud-init analyze show -i cloud-init.log
Finished stage: (modules-final) 322.39400 seconds
Total Time: 338.82500 seconds
1 boot records analyzed
```