### PR TITLE
Add `pkg-config` and `libyaml-devel` for `sqlite3` and `psych` gems

### DIFF
--- a/cloud-init.yaml
+++ b/cloud-init.yaml
@@ -252,33 +252,35 @@ apt:
         -----END PGP PUBLIC KEY BLOCK-----
 
 packages:
-  - ruby-full
   - bundler
+  - eslint
+  - ffmpeg
   - git
-  - sqlite3
-  - libsqlite3-dev
-  - memcached
-  - redis-server
-  - rabbitmq-server
-  - postgresql
-  - postgresql-contrib
-  - libpq-dev
+  - imagemagick
   - libmysqlclient-dev
+  - libncurses5-dev
+  - libpq-dev
+  - libsqlite3-dev
   - libssl-dev
+  - libvips
   - libxml2
   - libxml2-dev
   - libxslt1-dev
-  - libncurses5-dev
-  - libvips
-  - nodejs
-  - yarn
-  - imagemagick
+  - libyaml-dev
+  - memcached
   - mupdf
   - mupdf-tools
-  - ffmpeg
-  - poppler-utils
+  - nodejs
   - npm
-  - eslint
+  - pkg-config
+  - poppler-utils
+  - postgresql
+  - postgresql-contrib
+  - rabbitmq-server
+  - redis-server
+  - ruby-full
+  - sqlite3
+  - yarn
 
 hostname: rails-dev-box
 users:


### PR DESCRIPTION
Also sorted the package name in alphabetical order.

Without this commit, `bundle install` fails to install  `psych` and `sqlite3` gems.

- psych

```ruby
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: /tmp/bundler20230131-37216-qrmz3ypsych-5.0.1/gems/psych-5.0.1/ext/psych
/usr/bin/ruby3.0 -I /usr/lib/ruby/vendor_ruby -r ./siteconf20230131-37216-l4p44k.rb extconf.rb
checking for yaml.h... no
yaml.h not found
*** extconf.rb failed ***
Could not create Makefile due to some reason, probably lack of necessary
libraries and/or headers.  Check the mkmf.log file for more details.  You may
need configuration options.

Provided configuration options:
	--with-opt-dir
	--without-opt-dir
	--with-opt-include
	--without-opt-include=${opt-dir}/include
	--with-opt-lib
	--without-opt-lib=${opt-dir}/lib
	--with-make-prog
	--without-make-prog
	--srcdir=.
	--curdir
	--ruby=/usr/bin/$(RUBY_BASE_NAME)3.0
	--with-libyaml-source-dir
	--without-libyaml-source-dir
	--with-yaml-0.1-config
	--without-yaml-0.1-config
	--with-pkg-config
	--without-pkg-config
	--with-libyaml-dir
	--without-libyaml-dir
	--with-libyaml-include
	--without-libyaml-include=${libyaml-dir}/include
	--with-libyaml-lib
	--without-libyaml-lib=${libyaml-dir}/lib

To see why this extension failed to compile, please check the mkmf.log which can be found here:

  /tmp/bundler20230131-37216-qrmz3ypsych-5.0.1/extensions/aarch64-linux/3.0.0/psych-5.0.1/mkmf.log

extconf failed, exit code 1

Gem files will remain installed in /tmp/bundler20230131-37216-qrmz3ypsych-5.0.1/gems/psych-5.0.1 for inspection.
Results logged to /tmp/bundler20230131-37216-qrmz3ypsych-5.0.1/extensions/aarch64-linux/3.0.0/psych-5.0.1/gem_make.out

  /usr/lib/ruby/vendor_ruby/rubygems/ext/builder.rb:95:in `run'
  /usr/lib/ruby/vendor_ruby/rubygems/ext/ext_conf_builder.rb:47:in `block in build'
  /usr/lib/ruby/3.0.0/tempfile.rb:317:in `open'
  /usr/lib/ruby/vendor_ruby/rubygems/ext/ext_conf_builder.rb:26:in `build'
  /usr/lib/ruby/vendor_ruby/rubygems/ext/builder.rb:164:in `build_extension'
  /usr/lib/ruby/vendor_ruby/rubygems/ext/builder.rb:198:in `block in build_extensions'
  /usr/lib/ruby/vendor_ruby/rubygems/ext/builder.rb:195:in `each'
  /usr/lib/ruby/vendor_ruby/rubygems/ext/builder.rb:195:in `build_extensions'
  /usr/lib/ruby/vendor_ruby/rubygems/installer.rb:851:in `build_extensions'
  /var/lib/gems/3.0.0/gems/bundler-2.3.22/lib/bundler/rubygems_gem_installer.rb:72:in `build_extensions'
  /var/lib/gems/3.0.0/gems/bundler-2.3.22/lib/bundler/rubygems_gem_installer.rb:28:in `install'
  /var/lib/gems/3.0.0/gems/bundler-2.3.22/lib/bundler/source/rubygems.rb:207:in `install'
  /var/lib/gems/3.0.0/gems/bundler-2.3.22/lib/bundler/installer/gem_installer.rb:54:in `install'
  /var/lib/gems/3.0.0/gems/bundler-2.3.22/lib/bundler/installer/gem_installer.rb:16:in `install_from_spec'
  /var/lib/gems/3.0.0/gems/bundler-2.3.22/lib/bundler/installer/parallel_installer.rb:186:in `do_install'
  /var/lib/gems/3.0.0/gems/bundler-2.3.22/lib/bundler/installer/parallel_installer.rb:177:in `block in worker_pool'
  /var/lib/gems/3.0.0/gems/bundler-2.3.22/lib/bundler/worker.rb:62:in `apply_func'
  /var/lib/gems/3.0.0/gems/bundler-2.3.22/lib/bundler/worker.rb:57:in `block in process_queue'
  /var/lib/gems/3.0.0/gems/bundler-2.3.22/lib/bundler/worker.rb:54:in `loop'
  /var/lib/gems/3.0.0/gems/bundler-2.3.22/lib/bundler/worker.rb:54:in `process_queue'
  /var/lib/gems/3.0.0/gems/bundler-2.3.22/lib/bundler/worker.rb:91:in `block (2 levels) in create_threads'

An error occurred while installing psych (5.0.1), and Bundler cannot continue.

In Gemfile:
  sdoc was resolved to 2.6.0, which depends on
    rdoc was resolved to 6.5.0, which depends on
      psych
```

- sqlite3

```ruby
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: /tmp/bundler20230131-37216-woyd5lsqlite3-1.5.4/gems/sqlite3-1.5.4/ext/sqlite3
/usr/bin/ruby3.0 -I /usr/lib/ruby/vendor_ruby -r ./siteconf20230131-37216-l9oabd.rb extconf.rb
Building sqlite3-ruby using packaged sqlite3.
Extracting sqlite-autoconf-3400000.tar.gz into tmp/aarch64-linux-gnu/ports/sqlite3/3.40.0... OK
Running 'configure' for sqlite3 3.40.0... OK
Running 'compile' for sqlite3 3.40.0... OK
Running 'install' for sqlite3 3.40.0... OK
Activating sqlite3 3.40.0 (from
/tmp/bundler20230131-37216-woyd5lsqlite3-1.5.4/gems/sqlite3-1.5.4/ports/aarch64-linux-gnu/sqlite3/3.40.0)...

Could not configure the build properly (pkg_config). Please install either the `pkg-config` utility or the `pkg-config` rubygem.

*** extconf.rb failed ***
Could not create Makefile due to some reason, probably lack of necessary
libraries and/or headers.  Check the mkmf.log file for more details.  You may
need configuration options.

Provided configuration options:
	--with-opt-dir
	--without-opt-dir
	--with-opt-include
	--without-opt-include=${opt-dir}/include
	--with-opt-lib
	--without-opt-lib=${opt-dir}/lib
	--with-make-prog
	--without-make-prog
	--srcdir=.
	--curdir
	--ruby=/usr/bin/$(RUBY_BASE_NAME)3.0
	--help
	--download-dependencies
	--with-sqlcipher
	--without-sqlcipher
	--with-sqlcipher-dir
	--without-sqlcipher-dir
	--with-sqlcipher-include
	--without-sqlcipher-include
	--with-sqlcipher-lib
	--without-sqlcipher-lib
	--enable-system-libraries
	--disable-system-libraries
	--with-sqlcipher
	--without-sqlcipher
	--with-sqlcipher-dir
	--without-sqlcipher-dir
	--with-sqlcipher-include
	--without-sqlcipher-include
	--with-sqlcipher-lib
	--without-sqlcipher-lib
	--with-sqlite-source-dir
--with-/tmp/bundler20230131-37216-woyd5lsqlite3-1.5.4/gems/sqlite3-1.5.4/ports/aarch64-linux-gnu/sqlite3/3.40.0/lib/pkgconfig/sqlite3.pc-config
--without-/tmp/bundler20230131-37216-woyd5lsqlite3-1.5.4/gems/sqlite3-1.5.4/ports/aarch64-linux-gnu/sqlite3/3.40.0/lib/pkgconfig/sqlite3.pc-config
	--with-pkg-config
	--without-pkg-config

To see why this extension failed to compile, please check the mkmf.log which can be found here:

  /tmp/bundler20230131-37216-woyd5lsqlite3-1.5.4/extensions/aarch64-linux/3.0.0/sqlite3-1.5.4/mkmf.log

extconf failed, exit code 1

Gem files will remain installed in /tmp/bundler20230131-37216-woyd5lsqlite3-1.5.4/gems/sqlite3-1.5.4 for inspection.
Results logged to /tmp/bundler20230131-37216-woyd5lsqlite3-1.5.4/extensions/aarch64-linux/3.0.0/sqlite3-1.5.4/gem_make.out

  /usr/lib/ruby/vendor_ruby/rubygems/ext/builder.rb:95:in `run'
  /usr/lib/ruby/vendor_ruby/rubygems/ext/ext_conf_builder.rb:47:in `block in build'
  /usr/lib/ruby/3.0.0/tempfile.rb:317:in `open'
  /usr/lib/ruby/vendor_ruby/rubygems/ext/ext_conf_builder.rb:26:in `build'
  /usr/lib/ruby/vendor_ruby/rubygems/ext/builder.rb:164:in `build_extension'
  /usr/lib/ruby/vendor_ruby/rubygems/ext/builder.rb:198:in `block in build_extensions'
  /usr/lib/ruby/vendor_ruby/rubygems/ext/builder.rb:195:in `each'
  /usr/lib/ruby/vendor_ruby/rubygems/ext/builder.rb:195:in `build_extensions'
  /usr/lib/ruby/vendor_ruby/rubygems/installer.rb:851:in `build_extensions'
  /var/lib/gems/3.0.0/gems/bundler-2.3.22/lib/bundler/rubygems_gem_installer.rb:72:in `build_extensions'
  /var/lib/gems/3.0.0/gems/bundler-2.3.22/lib/bundler/rubygems_gem_installer.rb:28:in `install'
  /var/lib/gems/3.0.0/gems/bundler-2.3.22/lib/bundler/source/rubygems.rb:207:in `install'
  /var/lib/gems/3.0.0/gems/bundler-2.3.22/lib/bundler/installer/gem_installer.rb:54:in `install'
  /var/lib/gems/3.0.0/gems/bundler-2.3.22/lib/bundler/installer/gem_installer.rb:16:in `install_from_spec'
  /var/lib/gems/3.0.0/gems/bundler-2.3.22/lib/bundler/installer/parallel_installer.rb:186:in `do_install'
  /var/lib/gems/3.0.0/gems/bundler-2.3.22/lib/bundler/installer/parallel_installer.rb:177:in `block in worker_pool'
  /var/lib/gems/3.0.0/gems/bundler-2.3.22/lib/bundler/worker.rb:62:in `apply_func'
  /var/lib/gems/3.0.0/gems/bundler-2.3.22/lib/bundler/worker.rb:57:in `block in process_queue'
  /var/lib/gems/3.0.0/gems/bundler-2.3.22/lib/bundler/worker.rb:54:in `loop'
  /var/lib/gems/3.0.0/gems/bundler-2.3.22/lib/bundler/worker.rb:54:in `process_queue'
  /var/lib/gems/3.0.0/gems/bundler-2.3.22/lib/bundler/worker.rb:91:in `block (2 levels) in create_threads'

An error occurred while installing sqlite3 (1.5.4), and Bundler cannot continue.

In Gemfile:
  sqlite3
```