### PR TITLE
Use Ubuntu 23.10 to install Ruby 3.1 that is required by Rails 7.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ You can run rails-dev-box on M1 mac using Multipass.
   ```
 3. Launch Multipass box
   ```shell
-  % multipass launch 22.04 -d 20G --name rails-dev-box --cloud-init ./cloud-init.yaml --timeout 600
+  % multipass launch 23.10 --cpus 2 --disk 20G --memory 2G --name rails-dev-box --cloud-init ./cloud-init.yaml --timeout 600
   ```
 4. Login to Multipass box
   ```shell


### PR DESCRIPTION
This pull request upgrades Ubuntu 23.10 to install Ruby 3.1 that is required by Rails 7.2.

- Bump CPU and Memory size
- Increased timeout value to avoid `Timed out waiting for instance launch.`

- Ruby version installed:
```
ubuntu@rails-dev-box:~$ ruby -v
ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [aarch64-linux-gnu]
```