### PR TITLE
Install libvips-dev

### DIFF
--- a/cloud-init.yaml
+++ b/cloud-init.yaml
@@ -262,7 +262,7 @@ packages:
   - libpq-dev
   - libsqlite3-dev
   - libssl-dev
-  - libvips
+  - libvips-dev
   - libxml2
   - libxml2-dev
   - libxslt1-dev


### PR DESCRIPTION
This commit addresses the following LoadError:

```ruby
$ git clone https://github.com/rails/rails
$ bundle update --bundler
$ bundle install
$ cd activestorage
$ bin/test test/models/preview_test.rb:7
Missing service configuration file in /home/ubuntu/rails/activestorage/test/service/configurations.yml
== 20170806125915 CreateActiveStorageTables: migrating ========================
-- create_table(:active_storage_blobs, {:id=>:primary_key})
   -> 0.0004s
-- create_table(:active_storage_attachments, {:id=>:primary_key})
   -> 0.0004s
-- create_table(:active_storage_variant_records, {:id=>:primary_key})
   -> 0.0002s
== 20170806125915 CreateActiveStorageTables: migrated (0.0011s) ===============

==  ActiveStorageCreateUsers: migrating =======================================
-- create_table(:users)
   -> 0.0002s
==  ActiveStorageCreateUsers: migrated (0.0002s) ==============================

==  ActiveStorageCreateGroups: migrating ======================================
-- create_table(:groups)
   -> 0.0001s
==  ActiveStorageCreateGroups: migrated (0.0001s) =============================

Run options: --seed 50938

Error:
ActiveStorage::PreviewTest#test_previewing_a_PDF:
LoadError: Could not open library 'vips.so.42': vips.so.42: cannot open shared object file: No such file or directory.
Could not open library 'libvips.so.42': libvips.so.42: cannot open shared object file: No such file or directory.
Searched in <system library path>
    /home/ubuntu/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/ffi-1.17.0/lib/ffi/dynamic_library.rb:94:in `load_library'
    /home/ubuntu/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/ffi-1.17.0/lib/ffi/library.rb:95:in `block in ffi_lib'
    /home/ubuntu/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/ffi-1.17.0/lib/ffi/library.rb:94:in `map'
    /home/ubuntu/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/ffi-1.17.0/lib/ffi/library.rb:94:in `ffi_lib'
    /home/ubuntu/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/ruby-vips-2.2.2/lib/vips.rb:46:in `<module:Vips>'
    /home/ubuntu/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/ruby-vips-2.2.2/lib/vips.rb:43:in `<top (required)>'
    /home/ubuntu/.rbenv/versions/3.3.4/lib/ruby/3.3.0/bundled_gems.rb:74:in `require'
    /home/ubuntu/.rbenv/versions/3.3.4/lib/ruby/3.3.0/bundled_gems.rb:74:in `block (2 levels) in replace_require'
    /home/ubuntu/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/zeitwerk-2.6.12/lib/zeitwerk/kernel.rb:38:in `require'
    /home/ubuntu/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/image_processing-1.12.2/lib/image_processing/vips.rb:1:in `<top (required)>'
    /home/ubuntu/.rbenv/versions/3.3.4/lib/ruby/3.3.0/bundled_gems.rb:74:in `require'
    /home/ubuntu/.rbenv/versions/3.3.4/lib/ruby/3.3.0/bundled_gems.rb:74:in `block (2 levels) in replace_require'
    /home/ubuntu/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/zeitwerk-2.6.12/lib/zeitwerk/kernel.rb:38:in `require'
    lib/active_storage/transformers/image_processing_transformer.rb:29:in `const_get'
    lib/active_storage/transformers/image_processing_transformer.rb:29:in `processor'
    lib/active_storage/transformers/image_processing_transformer.rb:20:in `process'
    lib/active_storage/transformers/transformer.rb:24:in `transform'
    app/models/active_storage/variation.rb:58:in `block in transform'
    /home/ubuntu/rails/activesupport/lib/active_support/notifications.rb:212:in `instrument'
    app/models/active_storage/variation.rb:57:in `transform'
    app/models/active_storage/variant_with_record.rb:49:in `block in transform_blob'
    lib/active_storage/downloader.rb:15:in `block in open'
    lib/active_storage/downloader.rb:24:in `open_tempfile'
    lib/active_storage/downloader.rb:12:in `open'
    lib/active_storage/service.rb:92:in `open'
    app/models/active_storage/blob.rb:305:in `open'
    app/models/active_storage/variant_with_record.rb:48:in `transform_blob'
    app/models/active_storage/variant_with_record.rb:44:in `process'
    app/models/active_storage/variant_with_record.rb:19:in `processed'
    app/models/active_storage/preview.rb:54:in `processed'
    test/models/preview_test.rb:9:in `block in <class:PreviewTest>'

bin/test test/models/preview_test.rb:7

Finished in 0.122747s, 8.1468 runs/s, 0.0000 assertions/s.
1 runs, 0 assertions, 0 failures, 1 errors, 0 skips
$
```