### PR TITLE
Add MYSQL_SOCK environment variable

### DIFF
--- a/cloud-init.yaml
+++ b/cloud-init.yaml
@@ -320,4 +320,5 @@ runcmd:
   - sudo -u ubuntu bash -c 'git clone https://github.com/rbenv/ruby-build.git /home/ubuntu/.rbenv/plugins/ruby-build'
   - sudo -u ubuntu bash -c '/home/ubuntu/.rbenv/bin/rbenv install 3.3.4'
   - sudo -u ubuntu bash -c '/home/ubuntu/.rbenv/bin/rbenv global 3.3.4'
+  - sudo -u ubuntu bash -c 'echo "export MYSQL_SOCK=/var/run/mysqld/mysqld.sock" >> /home/ubuntu/.bashrc'
 final_message: "all set, rock on!"


### PR DESCRIPTION
This pull request adds MYSQL_SOCK environment variable to address the following error.

```ruby
$ ARCONN=trilogy bin/test
Using trilogy
/home/ubuntu/rails/activerecord/lib/active_record/connection_adapters/trilogy_adapter.rb:34:in `rescue in new_client': No such file or directory - trilogy_connect - unable to connect to /tmp/mysql.sock (ActiveRecord::ConnectionNotEstablished)
	from /home/ubuntu/rails/activerecord/lib/active_record/connection_adapters/trilogy_adapter.rb:30:in `new_client'
	from /home/ubuntu/rails/activerecord/lib/active_record/connection_adapters/trilogy_adapter.rb:157:in `connect'
	from /home/ubuntu/rails/activerecord/lib/active_record/connection_adapters/trilogy_adapter.rb:165:in `reconnect'
	from /home/ubuntu/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:662:in `block in reconnect!'
	from /home/ubuntu/rails/activesupport/lib/active_support/concurrency/null_lock.rb:9:in `synchronize'
	from /home/ubuntu/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:661:in `reconnect!'
	from /home/ubuntu/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:763:in `block in verify!'
	from /home/ubuntu/rails/activesupport/lib/active_support/concurrency/null_lock.rb:9:in `synchronize'
	from /home/ubuntu/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:754:in `verify!'
	from /home/ubuntu/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:771:in `connect!'
	from /home/ubuntu/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:977:in `block in with_raw_connection'
	from /home/ubuntu/rails/activesupport/lib/active_support/concurrency/null_lock.rb:9:in `synchronize'
	from /home/ubuntu/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:976:in `with_raw_connection'
	from /home/ubuntu/rails/activerecord/lib/active_record/connection_adapters/trilogy_adapter.rb:173:in `get_full_version'
	from /home/ubuntu/rails/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:87:in `get_database_version'
	from /home/ubuntu/rails/activerecord/lib/active_record/connection_adapters/pool_config.rb:41:in `block in server_version'
	from /home/ubuntu/.rbenv/versions/3.3.4/lib/ruby/3.3.0/monitor.rb:201:in `synchronize'
	from /home/ubuntu/.rbenv/versions/3.3.4/lib/ruby/3.3.0/monitor.rb:201:in `mon_synchronize'
	from /home/ubuntu/rails/activerecord/lib/active_record/connection_adapters/pool_config.rb:41:in `server_version'
	from /home/ubuntu/rails/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:212:in `server_version'
	from /home/ubuntu/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:847:in `database_version'
	from /home/ubuntu/rails/activerecord/lib/active_record/connection_adapters/trilogy_adapter.rb:169:in `full_version'
	from /home/ubuntu/rails/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:93:in `mariadb?'
	from /home/ubuntu/rails/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb:140:in `row_format_dynamic_by_default?'
	from /home/ubuntu/rails/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb:148:in `default_row_format'
	from /home/ubuntu/rails/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb:84:in `create_table'
	from /home/ubuntu/rails/activerecord/lib/active_record/migration/default_strategy.rb:10:in `method_missing'
	from /home/ubuntu/rails/activerecord/lib/active_record/migration.rb:1063:in `block in method_missing'
	from /home/ubuntu/rails/activerecord/lib/active_record/migration.rb:1029:in `block in say_with_time'
	from /home/ubuntu/.rbenv/versions/3.3.4/lib/ruby/3.3.0/benchmark.rb:298:in `measure'
	from /home/ubuntu/rails/activerecord/lib/active_record/migration.rb:1029:in `say_with_time'
	from /home/ubuntu/rails/activerecord/lib/active_record/migration.rb:1052:in `method_missing'
	from /home/ubuntu/rails/activerecord/lib/active_record/migration.rb:585:in `create_table'
	from /home/ubuntu/rails/activerecord/test/schema/schema.rb:11:in `block in <top (required)>'
	from /home/ubuntu/rails/activerecord/lib/active_record/schema.rb:56:in `instance_eval'
	from /home/ubuntu/rails/activerecord/lib/active_record/schema.rb:56:in `block in define'
	from /home/ubuntu/rails/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:407:in `with_connection'
	from /home/ubuntu/rails/activerecord/lib/active_record/schema.rb:55:in `define'
	from /home/ubuntu/rails/activerecord/lib/active_record/schema.rb:50:in `define'
	from /home/ubuntu/rails/activerecord/test/schema/schema.rb:3:in `<top (required)>'
	from /home/ubuntu/rails/activerecord/test/support/load_schema_helper.rb:12:in `load'
	from /home/ubuntu/rails/activerecord/test/support/load_schema_helper.rb:12:in `load_schema'
	from /home/ubuntu/rails/activerecord/test/cases/test_case.rb:299:in `<class:TestCase>'
	from /home/ubuntu/rails/activerecord/test/cases/test_case.rb:21:in `<module:ActiveRecord>'
	from /home/ubuntu/rails/activerecord/test/cases/test_case.rb:17:in `<top (required)>'
	from /home/ubuntu/.rbenv/versions/3.3.4/lib/ruby/3.3.0/bundled_gems.rb:74:in `require'
	from /home/ubuntu/.rbenv/versions/3.3.4/lib/ruby/3.3.0/bundled_gems.rb:74:in `block (2 levels) in replace_require'
	from /home/ubuntu/rails/activerecord/test/cases/helper.rb:8:in `<top (required)>'
	from /home/ubuntu/.rbenv/versions/3.3.4/lib/ruby/3.3.0/bundled_gems.rb:74:in `require'
	from /home/ubuntu/.rbenv/versions/3.3.4/lib/ruby/3.3.0/bundled_gems.rb:74:in `block (2 levels) in replace_require'
	from /home/ubuntu/rails/activerecord/test/activejob/destroy_association_async_job_test.rb:3:in `<top (required)>'
	from /home/ubuntu/.rbenv/versions/3.3.4/lib/ruby/3.3.0/bundled_gems.rb:74:in `require'
	from /home/ubuntu/.rbenv/versions/3.3.4/lib/ruby/3.3.0/bundled_gems.rb:74:in `block (2 levels) in replace_require'
	from /home/ubuntu/rails/railties/lib/rails/test_unit/runner.rb:62:in `block in load_tests'
	from /home/ubuntu/rails/railties/lib/rails/test_unit/runner.rb:60:in `each'
	from /home/ubuntu/rails/railties/lib/rails/test_unit/runner.rb:60:in `load_tests'
	from /home/ubuntu/rails/railties/lib/rails/test_unit/runner.rb:52:in `run'
	from /home/ubuntu/rails/activerecord/test/support/tools.rb:37:in `<top (required)>'
	from bin/test:11:in `require_relative'
	from bin/test:11:in `<main>'
/home/ubuntu/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/trilogy-2.7.0/lib/trilogy.rb:18:in `_connect': No such file or directory - trilogy_connect - unable to connect to /tmp/mysql.sock (Trilogy::SyscallError::ENOENT)
	from /home/ubuntu/.rbenv/versions/3.3.4/lib/ruby/gems/3.3.0/gems/trilogy-2.7.0/lib/trilogy.rb:18:in `initialize'
	from /home/ubuntu/rails/activerecord/lib/active_record/connection_adapters/trilogy_adapter.rb:32:in `new'
	from /home/ubuntu/rails/activerecord/lib/active_record/connection_adapters/trilogy_adapter.rb:32:in `new_client'
	from /home/ubuntu/rails/activerecord/lib/active_record/connection_adapters/trilogy_adapter.rb:157:in `connect'
	from /home/ubuntu/rails/activerecord/lib/active_record/connection_adapters/trilogy_adapter.rb:165:in `reconnect'
	from /home/ubuntu/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:662:in `block in reconnect!'
	from /home/ubuntu/rails/activesupport/lib/active_support/concurrency/null_lock.rb:9:in `synchronize'
	from /home/ubuntu/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:661:in `reconnect!'
	from /home/ubuntu/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:763:in `block in verify!'
	from /home/ubuntu/rails/activesupport/lib/active_support/concurrency/null_lock.rb:9:in `synchronize'
	from /home/ubuntu/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:754:in `verify!'
	from /home/ubuntu/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:771:in `connect!'
	from /home/ubuntu/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:977:in `block in with_raw_connection'
	from /home/ubuntu/rails/activesupport/lib/active_support/concurrency/null_lock.rb:9:in `synchronize'
	from /home/ubuntu/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:976:in `with_raw_connection'
	from /home/ubuntu/rails/activerecord/lib/active_record/connection_adapters/trilogy_adapter.rb:173:in `get_full_version'
	from /home/ubuntu/rails/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:87:in `get_database_version'
	from /home/ubuntu/rails/activerecord/lib/active_record/connection_adapters/pool_config.rb:41:in `block in server_version'
	from /home/ubuntu/.rbenv/versions/3.3.4/lib/ruby/3.3.0/monitor.rb:201:in `synchronize'
	from /home/ubuntu/.rbenv/versions/3.3.4/lib/ruby/3.3.0/monitor.rb:201:in `mon_synchronize'
	from /home/ubuntu/rails/activerecord/lib/active_record/connection_adapters/pool_config.rb:41:in `server_version'
	from /home/ubuntu/rails/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:212:in `server_version'
	from /home/ubuntu/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:847:in `database_version'
	from /home/ubuntu/rails/activerecord/lib/active_record/connection_adapters/trilogy_adapter.rb:169:in `full_version'
	from /home/ubuntu/rails/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:93:in `mariadb?'
	from /home/ubuntu/rails/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb:140:in `row_format_dynamic_by_default?'
	from /home/ubuntu/rails/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb:148:in `default_row_format'
	from /home/ubuntu/rails/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb:84:in `create_table'
	from /home/ubuntu/rails/activerecord/lib/active_record/migration/default_strategy.rb:10:in `method_missing'
	from /home/ubuntu/rails/activerecord/lib/active_record/migration.rb:1063:in `block in method_missing'
	from /home/ubuntu/rails/activerecord/lib/active_record/migration.rb:1029:in `block in say_with_time'
	from /home/ubuntu/.rbenv/versions/3.3.4/lib/ruby/3.3.0/benchmark.rb:298:in `measure'
	from /home/ubuntu/rails/activerecord/lib/active_record/migration.rb:1029:in `say_with_time'
	from /home/ubuntu/rails/activerecord/lib/active_record/migration.rb:1052:in `method_missing'
	from /home/ubuntu/rails/activerecord/lib/active_record/migration.rb:585:in `create_table'
	from /home/ubuntu/rails/activerecord/test/schema/schema.rb:11:in `block in <top (required)>'
	from /home/ubuntu/rails/activerecord/lib/active_record/schema.rb:56:in `instance_eval'
	from /home/ubuntu/rails/activerecord/lib/active_record/schema.rb:56:in `block in define'
	from /home/ubuntu/rails/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:407:in `with_connection'
	from /home/ubuntu/rails/activerecord/lib/active_record/schema.rb:55:in `define'
	from /home/ubuntu/rails/activerecord/lib/active_record/schema.rb:50:in `define'
	from /home/ubuntu/rails/activerecord/test/schema/schema.rb:3:in `<top (required)>'
	from /home/ubuntu/rails/activerecord/test/support/load_schema_helper.rb:12:in `load'
	from /home/ubuntu/rails/activerecord/test/support/load_schema_helper.rb:12:in `load_schema'
	from /home/ubuntu/rails/activerecord/test/cases/test_case.rb:299:in `<class:TestCase>'
	from /home/ubuntu/rails/activerecord/test/cases/test_case.rb:21:in `<module:ActiveRecord>'
	from /home/ubuntu/rails/activerecord/test/cases/test_case.rb:17:in `<top (required)>'
	from /home/ubuntu/.rbenv/versions/3.3.4/lib/ruby/3.3.0/bundled_gems.rb:74:in `require'
	from /home/ubuntu/.rbenv/versions/3.3.4/lib/ruby/3.3.0/bundled_gems.rb:74:in `block (2 levels) in replace_require'
	from /home/ubuntu/rails/activerecord/test/cases/helper.rb:8:in `<top (required)>'
	from /home/ubuntu/.rbenv/versions/3.3.4/lib/ruby/3.3.0/bundled_gems.rb:74:in `require'
	from /home/ubuntu/.rbenv/versions/3.3.4/lib/ruby/3.3.0/bundled_gems.rb:74:in `block (2 levels) in replace_require'
	from /home/ubuntu/rails/activerecord/test/activejob/destroy_association_async_job_test.rb:3:in `<top (required)>'
	from /home/ubuntu/.rbenv/versions/3.3.4/lib/ruby/3.3.0/bundled_gems.rb:74:in `require'
	from /home/ubuntu/.rbenv/versions/3.3.4/lib/ruby/3.3.0/bundled_gems.rb:74:in `block (2 levels) in replace_require'
	from /home/ubuntu/rails/railties/lib/rails/test_unit/runner.rb:62:in `block in load_tests'
	from /home/ubuntu/rails/railties/lib/rails/test_unit/runner.rb:60:in `each'
	from /home/ubuntu/rails/railties/lib/rails/test_unit/runner.rb:60:in `load_tests'
	from /home/ubuntu/rails/railties/lib/rails/test_unit/runner.rb:52:in `run'
	from /home/ubuntu/rails/activerecord/test/support/tools.rb:37:in `<top (required)>'
	from bin/test:11:in `require_relative'
	from bin/test:11:in `<main>'
```