### PR TITLE
Install Chromium and fix selenium-manager for aarch64

### DIFF
--- a/cloud-init.yaml
+++ b/cloud-init.yaml
@@ -69,5 +69,14 @@ runcmd:
   - sudo -u ubuntu bash -c '~/.local/bin/mise install ruby@4.0'
   - sudo -u ubuntu bash -c '~/.local/bin/mise use --global ruby@4.0'
   - sudo -u ubuntu bash -c '~/.local/bin/mise use --global yarn@latest'
+  - snap install chromium
+  - ln -s /snap/bin/chromium.chromedriver /usr/local/bin/chromedriver
+  - |
+    cat > /usr/local/bin/selenium-manager << 'EOF'
+    #!/bin/bash
+    echo '{"logs":[],"result":{"driver_path":"/usr/local/bin/chromedriver","browser_path":"/snap/bin/chromium"}}'
+    EOF
+  - chmod +x /usr/local/bin/selenium-manager
   - sudo -u ubuntu bash -c 'echo "export MYSQL_SOCK=/var/run/mysqld/mysqld.sock" >> /home/ubuntu/.bashrc'
+  - sudo -u ubuntu bash -c 'echo "export SE_MANAGER_PATH=/usr/local/bin/selenium-manager" >> /home/ubuntu/.bashrc'
 final_message: "all set, rock on!"

--- a/cloud-init.yaml
+++ b/cloud-init.yaml
@@ -79,4 +79,5 @@ runcmd:
   - chmod +x /usr/local/bin/selenium-manager
   - sudo -u ubuntu bash -c 'echo "export MYSQL_SOCK=/var/run/mysqld/mysqld.sock" >> /home/ubuntu/.bashrc'
   - sudo -u ubuntu bash -c 'echo "export SE_MANAGER_PATH=/usr/local/bin/selenium-manager" >> /home/ubuntu/.bashrc'
+  - sudo -u ubuntu bash -c 'echo "export SE_MANAGER_PATH=/usr/local/bin/selenium-manager" >> /home/ubuntu/.profile'
 final_message: "all set, rock on!"


### PR DESCRIPTION
The selenium-webdriver gem bundles a selenium-manager binary compiled
for x86_64 only. On the aarch64 VM it fails with "Syntax error:
Unterminated quoted string", breaking system tests.

Fix by:
- Installing Chromium via snap (provides browser + chromedriver)
- Symlinking chromedriver to /usr/local/bin
- Creating a /usr/local/bin/selenium-manager wrapper script that
  outputs the expected JSON with the installed driver/browser paths
- Setting SE_MANAGER_PATH to point to the wrapper, bypassing the
  broken x86_64 binary

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
